### PR TITLE
test: fix chat provider unit test mocking for providerConnection

### DIFF
--- a/server/services/chatProviders/__tests__/claude.test.ts
+++ b/server/services/chatProviders/__tests__/claude.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../file', () => ({
   readFileAsText: vi.fn(),
 }))
 
-vi.mock('../providerConnection', () => ({
+vi.mock('../../providerConnection', () => ({
   resolveUpstreamConnection: vi.fn().mockResolvedValue({
     apiKey: 'sk-ant-test',
-    fetchFn: globalThis.fetch,
+    fetchFn: (...args: any[]) => globalThis.fetch(...args),
     baseUrl: 'https://api.anthropic.com',
   }),
 }))

--- a/server/services/chatProviders/__tests__/gemini.test.ts
+++ b/server/services/chatProviders/__tests__/gemini.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../file', () => ({
   readFileAsText: vi.fn(),
 }))
 
-vi.mock('../providerConnection', () => ({
+vi.mock('../../providerConnection', () => ({
   resolveUpstreamConnection: vi.fn().mockResolvedValue({
     apiKey: 'AIzaSyTest',
-    fetchFn: globalThis.fetch,
+    fetchFn: (...args: any[]) => globalThis.fetch(...args),
     baseUrl: 'https://generativelanguage.googleapis.com',
   }),
 }))

--- a/server/services/chatProviders/__tests__/openai.test.ts
+++ b/server/services/chatProviders/__tests__/openai.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../file', () => ({
   readFileAsText: vi.fn(),
 }))
 
-vi.mock('../providerConnection', () => ({
+vi.mock('../../providerConnection', () => ({
   resolveUpstreamConnection: vi.fn().mockResolvedValue({
     apiKey: 'sk-test',
-    fetchFn: globalThis.fetch,
+    fetchFn: (...args: any[]) => globalThis.fetch(...args),
     baseUrl: 'https://api.openai.com',
   }),
 }))

--- a/server/services/chatProviders/__tests__/openaiResponse.test.ts
+++ b/server/services/chatProviders/__tests__/openaiResponse.test.ts
@@ -14,10 +14,10 @@ vi.mock('../../file', () => ({
   readFileAsText: vi.fn(),
 }))
 
-vi.mock('../providerConnection', () => ({
+vi.mock('../../providerConnection', () => ({
   resolveUpstreamConnection: vi.fn().mockResolvedValue({
     apiKey: 'sk-test',
-    fetchFn: globalThis.fetch,
+    fetchFn: (...args: any[]) => globalThis.fetch(...args),
     baseUrl: 'https://api.openai.com',
   }),
 }))


### PR DESCRIPTION
### Motivation
- Unit tests for chat providers were accidentally calling the real `providerConnection` implementation and capturing `global.fetch` too early, which caused network/database side effects and multiple failing tests.

### Description
- Corrected the mocked module path from `../providerConnection` to `../../providerConnection` in chat provider tests so the actual import target is mocked.
- Changed the mocked `fetchFn` to a call-time wrapper `(...args) => globalThis.fetch(...args)` so per-test `global.fetch` stubs are honored instead of being captured at mock creation.
- Modified the four test files `server/services/chatProviders/__tests__/{openai,claude,gemini,openaiResponse}.test.ts` to apply these fixes.

### Testing
- Ran the targeted tests with `pnpm -s vitest server/services/chatProviders/__tests__/openai.test.ts server/services/chatProviders/__tests__/claude.test.ts server/services/chatProviders/__tests__/gemini.test.ts server/services/chatProviders/__tests__/openaiResponse.test.ts` and all tests passed.
- Prior to the fix the same suites exhibited network/database-related failures, and after the change those failures were resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae2552bae08325976f90d180a6aba9)